### PR TITLE
Shrink Docker image size from ~1.9G to ~103M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM rustlang/rust:nightly
-
-RUN cargo install diesel_cli --no-default-features --features postgres
+FROM rustlang/rust:nightly AS build
 
 WORKDIR /app
 COPY . .
 
 RUN cargo build --release
 
-RUN ldd /app/target/release/spaghetti
+FROM debian:buster-slim
 
-CMD ["/app/target/release/spaghetti"]
+WORKDIR /app
+COPY --from=build /app/target/release/spaghetti .
+
+RUN apt-get update && apt-get install -y libpq-dev
+
+CMD ["/app/spaghetti"]


### PR DESCRIPTION
* Used an additional stage with a slimmer base image for the runtime. We shouldn't need the full Rust build environment to run the application.
* Removed diesel_cli from the build process. This is only required for running Diesel CLI commands and currently isn't utilised in the container.

I tried to achieve a static binary by compiling for `x86_64-unknown-linux-musl`, hoping that I could then just use `scratch` as the base image for the runtime. This didn't end up working, possibly due to some dependencies relying on libraries to be dynamically linked (`libc` crate? Postgres compatibility for `diesel`?).

The next best thing I could think of doing was dropping the app into a smaller base image with all required libraries present.

While this is a start, it might be worth exploring something like [this](https://blog.oddbit.com/post/2015-02-05-creating-minimal-docker-images/) later.